### PR TITLE
Cria página de organizações homologadas

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require(`path`);
+const { orgs } = require('./src/lib/organizations')
 const { createFilePath } = require(`gatsby-source-filesystem`);
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
@@ -43,14 +44,28 @@ exports.createPages = async ({ graphql, actions }) => {
   }
 
   const posts = result.data.allMarkdownRemark.edges;
+  const postsTemplate = path.resolve(`./src/templates/post.js`)
 
   posts.forEach(({ node }) => {
     createPage({
       path: node.fields.slug,
-      component: path.resolve(`./src/templates/post.js`),
+      component: postsTemplate,
       context: {
         slug: node.fields.slug,
       },
     });
   });
+
+  const organizationTemplate = path.resolve('src/templates/organization.js');
+
+  orgs.forEach(({ slug }) => {
+    createPage({
+      path: `orgs/${slug}`,
+      component: organizationTemplate,
+      context: {
+        slug,
+      }
+    })
+  });
+
 };

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -1,18 +1,22 @@
 import React from "react";
 import { Link } from 'gatsby'
 
-import "../styles/card.css";
-
 const OrganizationCard = (props) => {
-  const info = props.info;
+  const org = props.info;
 
   return (
-    <Link to={`/orgs/${info.slug}`} className="card bg-dark-gray">
-      <div className="image-container-card">
-        <img src={info.logo} alt={info.name} />
+    <Link
+      to={`/orgs/${org.slug}`}
+      className="p-2 lg:w-1/3 w-full mx-0 md:mx-2 shadow-sm md:shadow-md my-1 md:my-3">
+      <div className="h-full flex items-center p-4">
+        <img alt={org.name} className="w-20 md:w-24 lg:w-32 xl:w-40 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
+        <div className="flex-grow">
+          <h2 className="text-gray-900 font-medium text-sm lg:text-base xl:text-xl">{org.name}</h2>
+          <p className="text-gray-500 text-xs lg:text-sm xl:text-base">{org.category}</p>
+        </div>
       </div>
-      <h3 className="text-white">{info.name}</h3>
     </Link>
+
   );
 };
 

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Link } from 'gatsby'
+
+import "../styles/card.css";
+
+const OrganizationCard = (props) => {
+  const info = props.info;
+
+  return (
+    <Link to={`/orgs/${info.slug}`} className="card bg-dark-gray">
+      <div className="image-container-card">
+        <img src={info.logo} alt={info.name} />
+      </div>
+      <h3 className="text-white">{info.name}</h3>
+    </Link>
+  );
+};
+
+export default OrganizationCard;

--- a/src/components/projectCard.js
+++ b/src/components/projectCard.js
@@ -1,12 +1,12 @@
 import React from "react";
 
-import "./project.css";
+import "../styles/card.css";
 
 const Project = (props) => {
   const info = props.info;
 
   return (
-    <div className="project">
+    <div className="card">
       <h3>Nome: {info.name}</h3>
       <p>Organização: {info.org} </p>
       <p>Descrição: {info.description} </p>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -94,7 +94,6 @@ SEO.propTypes = {
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
-  image: null,
 };
 
 export default SEO;

--- a/src/enums/orgCategory.js
+++ b/src/enums/orgCategory.js
@@ -1,0 +1,8 @@
+const categories = {
+  LAB: 'Laboratório de pesquisa e desenvolvimento da UFCG',
+  PARTNER: 'Organização parceira da OpenDevUFCG',
+  SUPPORTED: 'Organização apoiada por alguma das organizações parceiras',
+  STARS: 'Organização com repositório opensource com mais de 100 stars',
+}
+
+module.exports = categories

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -45,7 +45,16 @@ const orgs = [
     category: categories.LAB,
     github: "https://github.com/ufcg-lsd",
     logo: "https://i.imgur.com/oadrDYr.png"
-  }
+  },
+  {
+    name: "Coordenação de Graduação da UASC",
+    slug: "uasc",
+    description:
+      "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
+    category: categories.PARTNER,
+    github: "http://www.computacao.ufcg.edu.br/",
+    logo: "https://i.imgur.com/zlNkrUk.png",
+  },
 ];
 
 function getOrg(slug) {

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -1,0 +1,58 @@
+const categories = require('../enums/orgCategory');
+
+const orgs = [
+  {
+    name: "Open Knowledge Brasil",
+    slug: "open-knowledge",
+    description:
+      "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
+    category: categories.STARS,
+    github: "https://github.com/okfn-brasil",
+    logo: "https://www.ok.org.br/wp-content/themes/okbr/assets/images/logo.svg",
+  },
+  {
+    name: "VTEX / SPLab",
+    slug: 'vtex',
+    description:
+      "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
+    category: categories.LAB,
+    github: "https://github.com/vtex",
+    logo: "https://i.imgur.com/4Xu1F2m.png",
+  },
+  {
+    name: "Call Us What You Want",
+    slug: "calluswhatyouwant",
+    description:
+      "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
+    category: categories.PARTNER,
+    github: "https://github.com/calluswhatyouwant",
+    logo: "https://i.imgur.com/b35mKLg.png",
+  },
+  {
+    name: "CAESI - Centro Acadêmico de Ciência da Computação UFCG",
+    slug: "caesi",
+    description:
+      "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
+    category: categories.PARTNER,
+    github: "https://github.com/caesiufcg",
+    logo: "https://raw.githubusercontent.com/caesiufcg/caesi-documentos/master/imagens/logo-vazado.png",
+  },
+  {
+    name: "Laboratório de Sistemas Distribuídos",
+    slug: "lsd",
+    description:
+      "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
+    category: categories.LAB,
+    github: "https://github.com/ufcg-lsd",
+    logo: "https://i.imgur.com/oadrDYr.png"
+  }
+];
+
+function getOrg(slug) {
+  return orgs.find(org => org.slug === slug)
+}
+
+module.exports = {
+  orgs,
+  getOrg,
+}

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -8,7 +8,7 @@ const orgs = [
       "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
     category: categories.STARS,
     github: "https://github.com/okfn-brasil",
-    logo: "https://www.ok.org.br/wp-content/themes/okbr/assets/images/logo.svg",
+    logo: "https://i.imgur.com/GFqCFMu.png",
   },
   {
     name: "VTEX / SPLab",
@@ -17,7 +17,7 @@ const orgs = [
       "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
     category: categories.LAB,
     github: "https://github.com/vtex",
-    logo: "https://i.imgur.com/4Xu1F2m.png",
+    logo: "https://i.imgur.com/xS3ul8s.png",
   },
   {
     name: "Call Us What You Want",
@@ -26,10 +26,10 @@ const orgs = [
       "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
     category: categories.PARTNER,
     github: "https://github.com/calluswhatyouwant",
-    logo: "https://i.imgur.com/b35mKLg.png",
+    logo: "https://i.imgur.com/Dm8oHwK.png",
   },
   {
-    name: "CAESI - Centro Acadêmico de Ciência da Computação UFCG",
+    name: "CAESI - Centro Acadêmico de Ciência da Computação",
     slug: "caesi",
     description:
       "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
@@ -44,7 +44,7 @@ const orgs = [
       "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
     category: categories.LAB,
     github: "https://github.com/ufcg-lsd",
-    logo: "https://i.imgur.com/oadrDYr.png"
+    logo: "https://i.imgur.com/Y7OErgK.png"
   },
   {
     name: "Coordenação de Graduação da UASC",
@@ -53,7 +53,7 @@ const orgs = [
       "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
     category: categories.PARTNER,
     github: "http://www.computacao.ufcg.edu.br/",
-    logo: "https://i.imgur.com/zlNkrUk.png",
+    logo: "https://i.imgur.com/zH2iP6s.png",
   },
 ];
 

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -1,0 +1,22 @@
+import React from "react";
+import OrganizationCard from "../components/organizationCard";
+import Layout from "../components/layouts/layout";
+import { orgs } from "../lib/organizations";
+
+const OrgsPage = () => {
+  return (
+    <Layout title="Organizações">
+      <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
+        <div className="w-full flex flex-col pb-5 items-center justify-center">
+          <h1>Organizações</h1>
+        </div>
+        <div className="w-full px-10 md:px-32 flex flex-wrap justify-center">
+          {orgs.map((org, index) => (
+            <OrganizationCard info={org} key={index} />
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+export default OrgsPage;

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -10,7 +10,7 @@ const OrgsPage = () => {
         <div className="w-full flex flex-col pb-5 items-center justify-center">
           <h1>Organizações</h1>
         </div>
-        <div className="w-full px-10 md:px-32 flex flex-wrap justify-center">
+        <div className="w-full px-10 flex flex-wrap justify-center">
           {orgs.map((org, index) => (
             <OrganizationCard info={org} key={index} />
           ))}

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -6,7 +6,7 @@ import { projects } from "../lib/projects";
 const ProjectsPage = () => {
   return (
     <Layout title="Projetos">
-      <section className="py-10 flex flex-col w-full items-center justify-center">
+      <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
         <div className="w-full flex flex-col pb-5 items-center justify-center">
           <h1>Projetos</h1>
         </div>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Project from "../components/project";
+import ProjectCard from "../components/projectCard";
 import Layout from "../components/layouts/layout";
 import { projects } from "../lib/projects";
 
@@ -12,7 +12,7 @@ const ProjectsPage = () => {
         </div>
         <div className="w-full px-32 flex flex-wrap justify-center">
           {projects.map((project, index) => (
-            <Project info={project} key={index} />
+            <ProjectCard info={project} key={index} />
           ))}
         </div>
       </section>

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -1,5 +1,4 @@
-.project {
-    background-color: white;
+.card {
     color: #000;
     margin: 10px;
     display: flex;
@@ -11,6 +10,10 @@
     font-size: 0.8em;
 }
 
-.project:hover {
+.image-container-card {
+    width: 100px;
+}
+
+.card:hover {
     transform: scale(1.07);
 }

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -1,0 +1,31 @@
+.org-logo-container {
+  max-width: 250px;
+  overflow: hidden;
+}
+  
+.org-logo {
+  max-width: 250px;
+}
+
+.org-card {
+  @apply max-w-lg rounded bg-gray-100 overflow-hidden shadow-lg
+}
+
+.org-tag {
+  font-size: 0.6rem;
+  @apply font-bold uppercase rounded-md text-center p-2 bg-purple-800 text-gray-100
+}
+
+.divider {
+  border-top: 1px solid;
+  border-top-color: rgba(0,0,0,0.12);
+  @apply w-full my-4
+}
+
+.org-link {
+  @apply text-primary rounded-sm p-2 w-full text-center
+}
+
+.org-link:hover {
+  @apply bg-purple-600 text-white
+}

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -8,7 +8,7 @@
 }
 
 .org-description {
-  text-indent: 80px;
+  text-indent: 2.5rem;
   text-align: justify;
   @apply text-gray-500 mt-5 text-lg
 }

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -7,13 +7,15 @@
   max-width: 250px;
 }
 
-.org-card {
-  @apply max-w-lg rounded bg-gray-100 overflow-hidden shadow-lg
+.org-description {
+  text-indent: 80px;
+  text-align: justify;
+  @apply text-gray-500 mt-5 text-lg
 }
 
 .org-tag {
   font-size: 0.6rem;
-  @apply font-bold uppercase rounded-md text-center p-2 bg-purple-800 text-gray-100
+  @apply font-bold uppercase rounded-md text-center p-2 bg-gray-400 text-gray-600
 }
 
 .divider {

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -12,19 +12,19 @@ const Organization = (data) => {
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
       <article className="pt-20 w-full">
-        <div className="flex flex-col md:flex-row mr-auto w-auto items-center justify-center">
-          <div className="m-10 flex flex-col items-center max-w-sm">
-            <div className="org-logo-container">
-              <img className="org-logo" src={logo} alt={name} />
-            </div>
-            <p className="text-gray-500 mt-5 text-lg">
+        <div className="flex flex-col md:flex-row mr-auto w-auto items-center md:items-start justify-center">
+          <div className="m-10 flex flex-col items-center max-w-lg">
+            <div className="font-bold text-xl mb-2 text-center text-white">{name}</div>
+            <p className="org-description">
               {description}
             </p>
           </div>
 
-          <div className="org-card">
+          <div className="max-w-lg rounded-none md:rounded-sm bg-gray-100 overflow-hidden shadow-lg">
             <div className="px-8 py-6 flex flex-col items-center">
-              <div className="font-bold text-xl mb-2 text-gray-700">{name}</div>
+              <div className="org-logo-container">
+                <img className="org-logo" src={logo} alt={name} />
+              </div>
               <div className="org-tag">{category}</div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Link } from "gatsby";
+
+import { getOrg } from '../lib/organizations'
+import Layout from "../components/layouts/layout";
+import '../styles/organization.css'
+
+const Organization = (data) => {
+  const slug = data.pageContext.slug;
+  const { name, category, description, github, logo } = getOrg(slug);
+
+  return (
+    <Layout Layout title={name} className="bg-dark-gray" >
+      <article className="pt-20 w-full">
+        <div className="flex flex-col md:flex-row mr-auto w-auto justify-center">
+          <div className="m-10 flex flex-col items-center max-w-sm">
+            <div className="org-logo-container">
+              <img className="org-logo" src={logo} alt={name} />
+            </div>
+            <p className="text-gray-500 mt-5 text-lg">
+              {description}
+            </p>
+          </div>
+
+          <div className="org-card">
+            <div className="px-8 py-6 flex flex-col items-center">
+              <div className="font-bold text-xl mb-2 text-gray-700">{name}</div>
+              <div className="org-tag">{category}</div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Acessar o GitHub</a>
+              </div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Canal no Discord</a>
+              </div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Enviar e-mail</a>
+              </div>
+              <div className="divider" />
+              <p className="flex text-xs text-gray-700 font-bold self-start mb-3">Tópicos</p>
+              <div>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">nodejs</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ui</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ux</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">react</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">devweb</span>
+              </div>
+              <div className="divider" />
+              <div className="w-full mb-12 mt-10 text-center block justify-center">
+                <Link
+                  className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 rounded"
+                  to="/cronograma"
+                >
+                  Ver projetos
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </Layout>
+  )
+}
+
+export default Organization

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -12,7 +12,7 @@ const Organization = (data) => {
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
       <article className="pt-20 w-full">
-        <div className="flex flex-col md:flex-row mr-auto w-auto justify-center">
+        <div className="flex flex-col md:flex-row mr-auto w-auto items-center justify-center">
           <div className="m-10 flex flex-col items-center max-w-sm">
             <div className="org-logo-container">
               <img className="org-logo" src={logo} alt={name} />
@@ -39,16 +39,7 @@ const Organization = (data) => {
                 <a href={github} className="org-link">Enviar e-mail</a>
               </div>
               <div className="divider" />
-              <p className="flex text-xs text-gray-700 font-bold self-start mb-3">Tópicos</p>
-              <div>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">nodejs</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ui</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ux</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">react</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">devweb</span>
-              </div>
-              <div className="divider" />
-              <div className="w-full mb-12 mt-10 text-center block justify-center">
+              <div className="w-full mb-10 mt-8 text-center block justify-center">
                 <Link
                   className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 rounded"
                   to="/cronograma"

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { graphql } from "gatsby";
 
 import Layout from "../components/layouts/layout";


### PR DESCRIPTION
Esta PR adiciona página de organizações homologadas, e uma página para cada uma com o detalhamento.

Close #30 

#### O que foi feito?

Adicionei um campo no `createPages` do arquivo `gatsby-node.js` para criar as páginas das organizações, a partir de um array exportado em `src/lib/organizations.js`.

#### Como suas mudanças podem ser testadas?

#### Screenshots ou exemplos de uso


- [ ] Conserta bug
- [x] Nova funcionalidade
