### PR TITLE
Cria página de organizações homologadas

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require(`path`);
+const { orgs } = require('./src/lib/organizations')
 const { createFilePath } = require(`gatsby-source-filesystem`);
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
@@ -43,14 +44,28 @@ exports.createPages = async ({ graphql, actions }) => {
   }
 
   const posts = result.data.allMarkdownRemark.edges;
+  const postsTemplate = path.resolve(`./src/templates/post.js`)
 
   posts.forEach(({ node }) => {
     createPage({
       path: node.fields.slug,
-      component: path.resolve(`./src/templates/post.js`),
+      component: postsTemplate,
       context: {
         slug: node.fields.slug,
       },
     });
   });
+
+  const organizationTemplate = path.resolve('src/templates/organization.js');
+
+  orgs.forEach(({ slug }) => {
+    createPage({
+      path: `orgs/${slug}`,
+      component: organizationTemplate,
+      context: {
+        slug,
+      }
+    })
+  });
+
 };

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -9,7 +9,15 @@ const OrganizationCard = (props) => {
       to={`/orgs/${org.slug}`}
       className="p-2 lg:w-1/3 w-full mx-0 md:mx-2 shadow-sm md:shadow-md my-1 md:my-3">
       <div className="h-full flex items-center p-4">
-        <img alt={org.name} className="w-24 lg:w-32 xl:w-48 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
+        {org.logo ?
+          (
+            <img alt={org.name} className="w-24 lg:w-32 xl:w-48 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
+          ) :
+          (
+            <div className="w-24 lg:w-32 xl:w-48 bg-white flex items-center justify-center text-4xl lg:text-6xl font-bold text-secondary-400" >
+              {org.name[0]}
+            </div>
+          )}
         <div className="flex-grow">
           <h2 className="text-gray-900 font-medium text-sm lg:text-base xl:text-xl">{org.name}</h2>
           <p className="text-gray-500 text-xs lg:text-sm xl:text-base">{org.category}</p>

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -1,18 +1,22 @@
 import React from "react";
 import { Link } from 'gatsby'
 
-import "../styles/card.css";
-
 const OrganizationCard = (props) => {
-  const info = props.info;
+  const org = props.info;
 
   return (
-    <Link to={`/orgs/${info.slug}`} className="card bg-dark-gray">
-      <div className="image-container-card">
-        <img src={info.logo} alt={info.name} />
+    <Link
+      to={`/orgs/${org.slug}`}
+      className="p-2 lg:w-1/3 w-full mx-0 md:mx-2 shadow-sm md:shadow-md my-1 md:my-3">
+      <div className="h-full flex items-center p-4">
+        <img alt={org.name} className="w-20 md:w-24 lg:w-32 xl:w-40 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
+        <div className="flex-grow">
+          <h2 className="text-gray-900 font-medium text-sm lg:text-base xl:text-xl">{org.name}</h2>
+          <p className="text-gray-500 text-xs lg:text-sm xl:text-base">{org.category}</p>
+        </div>
       </div>
-      <h3 className="text-white">{info.name}</h3>
     </Link>
+
   );
 };
 

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Link } from 'gatsby'
+
+import "../styles/card.css";
+
+const OrganizationCard = (props) => {
+  const info = props.info;
+
+  return (
+    <Link to={`/orgs/${info.slug}`} className="card bg-dark-gray">
+      <div className="image-container-card">
+        <img src={info.logo} alt={info.name} />
+      </div>
+      <h3 className="text-white">{info.name}</h3>
+    </Link>
+  );
+};
+
+export default OrganizationCard;

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -14,7 +14,7 @@ const OrganizationCard = (props) => {
             <img alt={org.name} className="w-24 lg:w-32 xl:w-48 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
           ) :
           (
-            <div className="w-24 lg:w-32 xl:w-48 bg-white flex items-center justify-center text-4xl lg:text-6xl font-bold text-secondary-400" >
+            <div className="w-24 lg:w-32 xl:w-48 bg-gray-100 flex items-center justify-center text-4xl lg:text-6xl font-bold text-secondary-400" >
               {org.name[0]}
             </div>
           )}

--- a/src/components/organizationCard.js
+++ b/src/components/organizationCard.js
@@ -9,7 +9,7 @@ const OrganizationCard = (props) => {
       to={`/orgs/${org.slug}`}
       className="p-2 lg:w-1/3 w-full mx-0 md:mx-2 shadow-sm md:shadow-md my-1 md:my-3">
       <div className="h-full flex items-center p-4">
-        <img alt={org.name} className="w-20 md:w-24 lg:w-32 xl:w-40 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
+        <img alt={org.name} className="w-24 lg:w-32 xl:w-48 object-cover object-center flex-shrink-0 mr-4" src={org.logo} />
         <div className="flex-grow">
           <h2 className="text-gray-900 font-medium text-sm lg:text-base xl:text-xl">{org.name}</h2>
           <p className="text-gray-500 text-xs lg:text-sm xl:text-base">{org.category}</p>

--- a/src/components/projectCard.js
+++ b/src/components/projectCard.js
@@ -1,12 +1,12 @@
 import React from "react";
 
-import "./project.css";
+import "../styles/card.css";
 
 const Project = (props) => {
   const info = props.info;
 
   return (
-    <div className="project">
+    <div className="card">
       <h3>Nome: {info.name}</h3>
       <p>Organização: {info.org} </p>
       <p>Descrição: {info.description} </p>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -94,7 +94,6 @@ SEO.propTypes = {
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
-  image: null,
 };
 
 export default SEO;

--- a/src/enums/orgCategory.js
+++ b/src/enums/orgCategory.js
@@ -1,0 +1,8 @@
+const categories = {
+  LAB: 'Laboratório de pesquisa e desenvolvimento da UFCG',
+  PARTNER: 'Organização parceira da OpenDevUFCG',
+  SUPPORTED: 'Organização apoiada por alguma das organizações parceiras',
+  STARS: 'Organização com repositório opensource com mais de 100 stars',
+}
+
+module.exports = categories

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -184,7 +184,7 @@ const orgs = [
     description:
       "O Django Public Admin surgiu para ajudar projetos que querem disponibilizar dados publicamente, para humanos, utilizando todo o poder do Django Admin _ mas sem precisar criar contas de usuários, fazer login etc.",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/vAhQWdr",
     email: "cuducos@gmail.com",
   },
   {
@@ -194,7 +194,7 @@ const orgs = [
     description:
       "A Calculadora do Cidadão é um pacote em Python para efetuar correção monetária de valores, muito útil em análise históricas. A ideia é criar uma interface unificada para diversos índices econômicos — atualmente temos família IPCA, IGPM, Taxa Selic e FED (EUA).",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/xbg2U6d",
     email: "cuducos@gmail.com",
   },
   {
@@ -204,7 +204,7 @@ const orgs = [
     description:
       "O Minha Receita é uma solução para que pequenas organizações tenham sua própria API web para consulta de informações sobre CNPJ. É uma API construída com base nos dados gerados pela Receita Federal e tratados pelo Brasil.IO.",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/P4aNMN2",
     email: "cuducos@gmail.com",
   },
   {
@@ -214,7 +214,7 @@ const orgs = [
     description:
       "Flask-SimpleLogin é a solução mais fácil para um sistema super fácil e simples de autenticação de usuário em Flask. Ideal para pequenos projetos, protótipos e MVPs.",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/34jAec4",
     email: "cuducos@gmail.com",
   },
   {
@@ -224,7 +224,7 @@ const orgs = [
     description:
       "Flask-AlchemyDumps é uma ferramenta simples de backup de banco de dados para aplicações que utilizam Flask e Flask-SQLAlchemy.",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/CtVDtcm",
     email: "cuducos@gmail.com",
   },
   {
@@ -234,7 +234,7 @@ const orgs = [
     description:
       "GetGist é um programa de linha de comando que permite acesso e atualização de Gists no GitHub como se fossem arquivos locais.",
     category: categories.PARTNER,
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/fcNvXsd",
     email: "cuducos@gmail.com",
   },
 ];

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -45,7 +45,16 @@ const orgs = [
     category: categories.LAB,
     github: "https://github.com/ufcg-lsd",
     logo: "https://i.imgur.com/oadrDYr.png"
-  }
+  },
+  {
+    name: "Coordenação de Graduação da UASC",
+    slug: "uasc",
+    description:
+      "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
+    category: categories.PARTNER,
+    github: "http://www.computacao.ufcg.edu.br/",
+    logo: "https://i.imgur.com/zlNkrUk.png",
+  },
 ];
 
 function getOrg(slug) {

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -9,24 +9,7 @@ const orgs = [
     category: categories.STARS,
     github: "https://github.com/okfn-brasil",
     logo: "https://i.imgur.com/GFqCFMu.png",
-  },
-  {
-    name: "VTEX / SPLab",
-    slug: 'vtex',
-    description:
-      "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
-    category: categories.LAB,
-    github: "https://github.com/vtex",
-    logo: "https://i.imgur.com/xS3ul8s.png",
-  },
-  {
-    name: "Call Us What You Want",
-    slug: "calluswhatyouwant",
-    description:
-      "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
-    category: categories.PARTNER,
-    github: "https://github.com/calluswhatyouwant",
-    logo: "https://i.imgur.com/Dm8oHwK.png",
+    email: "mario@ok.org.br",
   },
   {
     name: "CAESI - Centro Acadêmico de Ciência da Computação",
@@ -36,6 +19,27 @@ const orgs = [
     category: categories.PARTNER,
     github: "https://github.com/caesiufcg",
     logo: "https://raw.githubusercontent.com/caesiufcg/caesi-documentos/master/imagens/logo-vazado.png",
+    email: "caesi@ccc.ufcg.edu.br",
+  },
+  {
+    name: "VTEX / SPLab",
+    slug: 'vtex',
+    description:
+      "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
+    category: categories.LAB,
+    github: "https://github.com/vtex",
+    logo: "https://i.imgur.com/xS3ul8s.png",
+    email: "thayannevls@gmail.com",
+  },
+  {
+    name: "Call Us What You Want",
+    slug: "calluswhatyouwant",
+    description:
+      "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
+    category: categories.PARTNER,
+    github: "https://github.com/calluswhatyouwant",
+    logo: "https://i.imgur.com/Dm8oHwK.png",
+    email: "jrobsonjr16@gmail.com",
   },
   {
     name: "Laboratório de Sistemas Distribuídos",
@@ -44,7 +48,8 @@ const orgs = [
       "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
     category: categories.LAB,
     github: "https://github.com/ufcg-lsd",
-    logo: "https://i.imgur.com/Y7OErgK.png"
+    logo: "https://i.imgur.com/Y7OErgK.png",
+    email: "fubica@dsc.ufcg.edu.br",
   },
   {
     name: "Coordenação de Graduação da UASC",
@@ -54,6 +59,27 @@ const orgs = [
     category: categories.PARTNER,
     github: "http://www.computacao.ufcg.edu.br/",
     logo: "https://i.imgur.com/zH2iP6s.png",
+    email: "fubica@dsc.ufcg.edu.br",
+  },
+  {
+    name: "PET - Computação",
+    slug: "pet",
+    description:
+      "O grupo PET-Computação é reconhecido por realizar atividades indissociáveis entre ensino, pesquisa e extensão tanto dentro da comunidade acadêmica do curso de Ciência da Computação quanto na sociedade em geral.",
+    category: categories.PARTNER,
+    github: "http://www.dsc.ufcg.edu.br/~pet/",
+    logo: "https://i.imgur.com/7ncijtD.png",
+    email: "pet@ccc.ufcg.edu.br",
+  },
+  {
+    name: "dadosjusbr.org",
+    slug: "dadosjusbr",
+    description:
+      "Os principais objetivos do projeto dadosjusbr.org são denunciar a dificuldade no acesso, libertar e consolidar as informações sobre remunerações do sistema de justiça.  Iniciaremos com a esfera estadual e federal dos ministérios públicos e os tribunais eleitorais, do trabalho e de justiça. Fazemos isso combinando a construção comunitária de programas coletores de dados de remunerações com um sistema que consolida, calcula as dificuldades de acessar os dados de cada órgão e publica todas essas informações. ",
+    category: categories.SUPPORTED,
+    github: "https://github.com/dadosjusbr",
+    logo: "https://i.imgur.com/SrxbE5X.png",
+    email: "danielfireman@gmail.com",
   },
 ];
 

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -174,7 +174,7 @@ const orgs = [
       "O Alt Zap é uma aplicação feita para ajudar pequenos e médios negócios a venderem na internet, especialmente pra quem faz entrega por delivery. Atualmente usa tecnologias modernas como React, Gatsby e Firebase e já temos um roadmap bem definido para ser implementado!",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/nTUJq2g.png",
-    discord: "https://discord.gg/yzhste8",
+    discord: "https://discord.gg/qtpc4SD",
     email: "lucis@vtex.com",
   },
   {
@@ -237,7 +237,14 @@ const orgs = [
     discord: "https://discord.gg/fcNvXsd",
     email: "cuducos@gmail.com",
   },
-];
+].sort((a, b) => {
+  const nameA = a.name.toUpperCase()
+  const nameB = b.name.toUpperCase()
+  console.log(nameA, nameB)
+  if(nameA < nameB) { return -1; }
+  if(nameA > nameB) { return 1; }
+  return 0;
+});
 
 function getOrg(slug) {
   return orgs.find(org => org.slug === slug)

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -9,6 +9,7 @@ const orgs = [
       "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
     category: categories.STARS,
     logo: "https://i.imgur.com/GFqCFMu.png",
+    discord: "https://discord.gg/PASGyqa",
     email: "mario@ok.org.br",
   },
   {
@@ -19,6 +20,7 @@ const orgs = [
       "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
     category: categories.PARTNER,
     logo: "https://raw.githubusercontent.com/caesiufcg/caesi-documentos/master/imagens/logo-vazado.png",
+    discord: "https://discord.gg/DstfN83",
     email: "caesi@ccc.ufcg.edu.br",
   },
   {
@@ -29,6 +31,7 @@ const orgs = [
       "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
     category: categories.LAB,
     logo: "https://i.imgur.com/xS3ul8s.png",
+    discord: "https://discord.gg/yzhste8",
     email: "thayannevls@gmail.com",
   },
   {
@@ -39,6 +42,7 @@ const orgs = [
       "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/Dm8oHwK.png",
+    discord: "https://discord.gg/yhKDD4Y",
     email: "jrobsonjr16@gmail.com",
   },
   {
@@ -49,6 +53,7 @@ const orgs = [
       "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
     category: categories.LAB,
     logo: "https://i.imgur.com/Y7OErgK.png",
+    discord: "https://discord.gg/gSd32g9",
     email: "fubica@dsc.ufcg.edu.br",
   },
   {
@@ -59,6 +64,7 @@ const orgs = [
       "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/zH2iP6s.png",
+    discord: 'https://discord.gg/p63T93J',
     email: "fubica@dsc.ufcg.edu.br",
   },
   {
@@ -69,6 +75,7 @@ const orgs = [
       "O grupo PET-Computação é reconhecido por realizar atividades indissociáveis entre ensino, pesquisa e extensão tanto dentro da comunidade acadêmica do curso de Ciência da Computação quanto na sociedade em geral.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/7ncijtD.png",
+    discord: "https://discord.gg/dcfg7Gd",
     email: "pet@ccc.ufcg.edu.br",
   },
   {
@@ -79,6 +86,7 @@ const orgs = [
       "Os principais objetivos do projeto dadosjusbr.org são denunciar a dificuldade no acesso, libertar e consolidar as informações sobre remunerações do sistema de justiça.  Iniciaremos com a esfera estadual e federal dos ministérios públicos e os tribunais eleitorais, do trabalho e de justiça. Fazemos isso combinando a construção comunitária de programas coletores de dados de remunerações com um sistema que consolida, calcula as dificuldades de acessar os dados de cada órgão e publica todas essas informações.",
     category: categories.SUPPORTED,
     logo: "https://i.imgur.com/SrxbE5X.png",
+    discord: "https://discord.gg/bQZDKZe",
     email: "danielfireman@gmail.com",
   },
   {
@@ -89,6 +97,7 @@ const orgs = [
       "Os Guardians é um grupo voluntário de alunos preocupados com a disseminação de conhecimento sobre administração de sistemas. São responsáveis por realizar tarefas de manutenção nos laboratórios de informática da UFCG, bem como desenvolver software, realizar seminários e disseminar sobre a cultura da área.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/7Dnxli4.png",
+    discord: "https://discord.gg/6WvswEd",
     email: "matheusgr@computacao.ufcg.edu.br",
   },
   {
@@ -99,6 +108,7 @@ const orgs = [
       "O SPLab é um laboratório de ensino, pesquisa, inovação e desenvolvimento cujo tema central de interesse são as Práticas de Software. O SPLab tem por missão produzir e disseminar conhecimento sobre práticas de desenvolvimento de software tendo como norte a excelência na formação de recursos humanos.",
     category: categories.LAB,
     logo: "https://i.imgur.com/YMVDAX8.png",
+    discord: "https://discord.gg/ccpvexv",
     email: "matheusgr@computacao.ufcg.edu.br",
   },
   {
@@ -109,6 +119,7 @@ const orgs = [
       "Comunidade criada na UFCG por todas as mulheres na área de tecnologia",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/KzS6nSL.png",
+    discord: "https://discord.gg/m9nck96",
     email: "emilly.oliveira@ccc.ufcg.edu.br",
   },
   {
@@ -119,6 +130,7 @@ const orgs = [
       "A nossa frente é uma articulação de diferentes entidades que lutam pelo direito à cidade. Temos como pauta viabilizar políticas públicas de desenvolvimento urbano para a inclusão social e efetivação dos direitos humanos, sociais, ambientais e culturais, enfrentando as desigualdades e discriminações de gênero, raça e etnia.",
     category: categories.SUPPORTED,
     logo: "https://i.imgur.com/t1BEAih.png",
+    discord: "https://discord.gg/ucQnvwK",
     email: "frentepelodireitoacidade@gmail.com",
   },
   {
@@ -129,6 +141,7 @@ const orgs = [
       "O Laboratório de Rua, o LabRua, é uma associação sem fins lucrativos que atua na realização de pesquisas e eventos que envolvam o entendimento e funcionamento das cidades. Nascemos em 2015, em Campina Grande, na Paraíba, e desde então viemos desenvolvendo projetos focados em espaços públicos de nossa cidade e de outras localidades próximas. Entendendo a cidade como uma construção multidisciplinar, e a importância de uma contribuição colaborativa, buscamos sempre a participação de profissionais de diferentes áreas. Nossas ações possuem diferentes temáticas, mas nosso foco principal é a elaboração de pesquisas que possam tanto embasar o desenho urbano dos espaços públicos estudados, como também dar subsídios para políticas públicas que contemplem uma cidade mais democrática. Entre outros objetivos, está também o de informar a população sobre os aspectos que envolvem a cidade, produzindo eventos e conteúdos informativos a partir de nossas pesquisas e análises, além de realizar ações que lidem com a cidade direta e indiretamente, como a assessoria técnica urbanística e/ou arquitetônica, ocupações em espaços públicos e intervenções urbanas. Aprendendo e ensinando sobre assuntos que tenham repercussão na espaço urbano. Alguns exemplos dessas ações são nosso cinema, 'CineLab'; nossa roda de discussão, 'Janela'; o 'Debate' de livros e textos; a ocupação de espaços públicos, o 'Lab na Rua'; a famosa 'Maratona de Projetos'; entre outras.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/KY4wbUH.png",
+    discord: "https://discord.gg/BnQNhBu",
     email: "contato@labrua.org",
   },
   {
@@ -139,6 +152,7 @@ const orgs = [
       "Laboratório de pesquisa, desenvolvimento, ensino e inovação em Ciência de Dados Cívica.",
     category: categories.LAB,
     logo: "https://i.imgur.com/kQ8VM8I.png",
+    discord: 'https://discord.gg/gccDTYw',
     email: "nazareno@computacao.ufcg.edu.br",
   },
   {
@@ -149,6 +163,7 @@ const orgs = [
       "Comunidade na Paraíba com foco em ajudar mais mulheres a se tornarem participantes ativas e líderes da comunidade de código aberto Python.",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/vL74x2k.png",
+    discord: "https://discord.gg/7DEJAyM",
     email: "pb@pyladies.com",
   },
   {
@@ -159,6 +174,7 @@ const orgs = [
       "O Alt Zap é uma aplicação feita para ajudar pequenos e médios negócios a venderem na internet, especialmente pra quem faz entrega por delivery. Atualmente usa tecnologias modernas como React, Gatsby e Firebase e já temos um roadmap bem definido para ser implementado!",
     category: categories.PARTNER,
     logo: "https://i.imgur.com/nTUJq2g.png",
+    discord: "https://discord.gg/yzhste8",
     email: "lucis@vtex.com",
   },
 ];

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -1,0 +1,58 @@
+const categories = require('../enums/orgCategory');
+
+const orgs = [
+  {
+    name: "Open Knowledge Brasil",
+    slug: "open-knowledge",
+    description:
+      "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
+    category: categories.STARS,
+    github: "https://github.com/okfn-brasil",
+    logo: "https://www.ok.org.br/wp-content/themes/okbr/assets/images/logo.svg",
+  },
+  {
+    name: "VTEX / SPLab",
+    slug: 'vtex',
+    description:
+      "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
+    category: categories.LAB,
+    github: "https://github.com/vtex",
+    logo: "https://i.imgur.com/4Xu1F2m.png",
+  },
+  {
+    name: "Call Us What You Want",
+    slug: "calluswhatyouwant",
+    description:
+      "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
+    category: categories.PARTNER,
+    github: "https://github.com/calluswhatyouwant",
+    logo: "https://i.imgur.com/b35mKLg.png",
+  },
+  {
+    name: "CAESI - Centro Acadêmico de Ciência da Computação UFCG",
+    slug: "caesi",
+    description:
+      "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
+    category: categories.PARTNER,
+    github: "https://github.com/caesiufcg",
+    logo: "https://raw.githubusercontent.com/caesiufcg/caesi-documentos/master/imagens/logo-vazado.png",
+  },
+  {
+    name: "Laboratório de Sistemas Distribuídos",
+    slug: "lsd",
+    description:
+      "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
+    category: categories.LAB,
+    github: "https://github.com/ufcg-lsd",
+    logo: "https://i.imgur.com/oadrDYr.png"
+  }
+];
+
+function getOrg(slug) {
+  return orgs.find(org => org.slug === slug)
+}
+
+module.exports = {
+  orgs,
+  getOrg,
+}

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -4,82 +4,162 @@ const orgs = [
   {
     name: "Open Knowledge Brasil",
     slug: "open-knowledge",
+    representant: 'Mário Sérgio Oliveira de Queiroz',
     description:
       "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
     category: categories.STARS,
-    github: "https://github.com/okfn-brasil",
     logo: "https://i.imgur.com/GFqCFMu.png",
     email: "mario@ok.org.br",
   },
   {
     name: "CAESI - Centro Acadêmico de Ciência da Computação",
     slug: "caesi",
+    representant: 'Andrielly de Lima Lucena',
     description:
       "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
     category: categories.PARTNER,
-    github: "https://github.com/caesiufcg",
     logo: "https://raw.githubusercontent.com/caesiufcg/caesi-documentos/master/imagens/logo-vazado.png",
     email: "caesi@ccc.ufcg.edu.br",
   },
   {
     name: "VTEX / SPLab",
     slug: 'vtex',
+    representant: 'Thayanne Luiza Victor Landim Sousa',
     description:
       "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
     category: categories.LAB,
-    github: "https://github.com/vtex",
     logo: "https://i.imgur.com/xS3ul8s.png",
     email: "thayannevls@gmail.com",
   },
   {
     name: "Call Us What You Want",
     slug: "calluswhatyouwant",
+    representant: 'José Robson da Silva Araujo Junior',
     description:
       "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
     category: categories.PARTNER,
-    github: "https://github.com/calluswhatyouwant",
     logo: "https://i.imgur.com/Dm8oHwK.png",
     email: "jrobsonjr16@gmail.com",
   },
   {
     name: "Laboratório de Sistemas Distribuídos",
     slug: "lsd",
+    representant: 'Francisco Vilar Brasileiro',
     description:
       "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
     category: categories.LAB,
-    github: "https://github.com/ufcg-lsd",
     logo: "https://i.imgur.com/Y7OErgK.png",
     email: "fubica@dsc.ufcg.edu.br",
   },
   {
     name: "Coordenação de Graduação da UASC",
     slug: "uasc",
+    representant: 'Francisco Vilar Brasileiro',
     description:
       "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
     category: categories.PARTNER,
-    github: "http://www.computacao.ufcg.edu.br/",
     logo: "https://i.imgur.com/zH2iP6s.png",
     email: "fubica@dsc.ufcg.edu.br",
   },
   {
     name: "PET - Computação",
     slug: "pet",
+    representant: 'Marcelo Alves de Barros',
     description:
       "O grupo PET-Computação é reconhecido por realizar atividades indissociáveis entre ensino, pesquisa e extensão tanto dentro da comunidade acadêmica do curso de Ciência da Computação quanto na sociedade em geral.",
     category: categories.PARTNER,
-    github: "http://www.dsc.ufcg.edu.br/~pet/",
     logo: "https://i.imgur.com/7ncijtD.png",
     email: "pet@ccc.ufcg.edu.br",
   },
   {
     name: "dadosjusbr.org",
     slug: "dadosjusbr",
+    representant: 'Daniel Lacet de Faria Fireman',
     description:
-      "Os principais objetivos do projeto dadosjusbr.org são denunciar a dificuldade no acesso, libertar e consolidar as informações sobre remunerações do sistema de justiça.  Iniciaremos com a esfera estadual e federal dos ministérios públicos e os tribunais eleitorais, do trabalho e de justiça. Fazemos isso combinando a construção comunitária de programas coletores de dados de remunerações com um sistema que consolida, calcula as dificuldades de acessar os dados de cada órgão e publica todas essas informações. ",
+      "Os principais objetivos do projeto dadosjusbr.org são denunciar a dificuldade no acesso, libertar e consolidar as informações sobre remunerações do sistema de justiça.  Iniciaremos com a esfera estadual e federal dos ministérios públicos e os tribunais eleitorais, do trabalho e de justiça. Fazemos isso combinando a construção comunitária de programas coletores de dados de remunerações com um sistema que consolida, calcula as dificuldades de acessar os dados de cada órgão e publica todas essas informações.",
     category: categories.SUPPORTED,
-    github: "https://github.com/dadosjusbr",
     logo: "https://i.imgur.com/SrxbE5X.png",
     email: "danielfireman@gmail.com",
+  },
+  {
+    name: "Guardians",
+    slug: "guardians",
+    representant: 'Matheus Gaudencio do Rêgo',
+    description:
+      "Os Guardians é um grupo voluntário de alunos preocupados com a disseminação de conhecimento sobre administração de sistemas. São responsáveis por realizar tarefas de manutenção nos laboratórios de informática da UFCG, bem como desenvolver software, realizar seminários e disseminar sobre a cultura da área.",
+    category: categories.PARTNER,
+    logo: "https://i.imgur.com/7Dnxli4.png",
+    email: "matheusgr@computacao.ufcg.edu.br",
+  },
+  {
+    name: "SPLab",
+    slug: "splab",
+    representant: 'Matheus Gaudencio do Rêgo',
+    description:
+      "O SPLab é um laboratório de ensino, pesquisa, inovação e desenvolvimento cujo tema central de interesse são as Práticas de Software. O SPLab tem por missão produzir e disseminar conhecimento sobre práticas de desenvolvimento de software tendo como norte a excelência na formação de recursos humanos.",
+    category: categories.LAB,
+    logo: "https://i.imgur.com/YMVDAX8.png",
+    email: "matheusgr@computacao.ufcg.edu.br",
+  },
+  {
+    name: "Elas Computação",
+    slug: "elas",
+    representant: 'Emilly de Albuquerque Oliveira',
+    description:
+      "Comunidade criada na UFCG por todas as mulheres na área de tecnologia",
+    category: categories.PARTNER,
+    logo: "https://i.imgur.com/KzS6nSL.png",
+    email: "emilly.oliveira@ccc.ufcg.edu.br",
+  },
+  {
+    name: "Frente pelo direito à cidade",
+    slug: "frente-pelo-direito-a-cidade",
+    representant: 'Jobson Brunno da Silva Lima',
+    description:
+      "A nossa frente é uma articulação de diferentes entidades que lutam pelo direito à cidade. Temos como pauta viabilizar políticas públicas de desenvolvimento urbano para a inclusão social e efetivação dos direitos humanos, sociais, ambientais e culturais, enfrentando as desigualdades e discriminações de gênero, raça e etnia.",
+    category: categories.SUPPORTED,
+    logo: "https://i.imgur.com/t1BEAih.png",
+    email: "frentepelodireitoacidade@gmail.com",
+  },
+  {
+    name: "Laboratório de Rua (LabRua)",
+    slug: "labrua",
+    representant: 'Aída Paula Pontes de Aquino',
+    description:
+      "O Laboratório de Rua, o LabRua, é uma associação sem fins lucrativos que atua na realização de pesquisas e eventos que envolvam o entendimento e funcionamento das cidades. Nascemos em 2015, em Campina Grande, na Paraíba, e desde então viemos desenvolvendo projetos focados em espaços públicos de nossa cidade e de outras localidades próximas. Entendendo a cidade como uma construção multidisciplinar, e a importância de uma contribuição colaborativa, buscamos sempre a participação de profissionais de diferentes áreas. Nossas ações possuem diferentes temáticas, mas nosso foco principal é a elaboração de pesquisas que possam tanto embasar o desenho urbano dos espaços públicos estudados, como também dar subsídios para políticas públicas que contemplem uma cidade mais democrática. Entre outros objetivos, está também o de informar a população sobre os aspectos que envolvem a cidade, produzindo eventos e conteúdos informativos a partir de nossas pesquisas e análises, além de realizar ações que lidem com a cidade direta e indiretamente, como a assessoria técnica urbanística e/ou arquitetônica, ocupações em espaços públicos e intervenções urbanas. Aprendendo e ensinando sobre assuntos que tenham repercussão na espaço urbano. Alguns exemplos dessas ações são nosso cinema, 'CineLab'; nossa roda de discussão, 'Janela'; o 'Debate' de livros e textos; a ocupação de espaços públicos, o 'Lab na Rua'; a famosa 'Maratona de Projetos'; entre outras.",
+    category: categories.PARTNER,
+    logo: "https://i.imgur.com/KY4wbUH.png",
+    email: "contato@labrua.org",
+  },
+  {
+    name: "Laboratório Analytics",
+    slug: "lab-analytics",
+    representant: 'Nazareno Andrade',
+    description:
+      "Laboratório de pesquisa, desenvolvimento, ensino e inovação em Ciência de Dados Cívica.",
+    category: categories.LAB,
+    logo: "https://i.imgur.com/kQ8VM8I.png",
+    email: "nazareno@computacao.ufcg.edu.br",
+  },
+  {
+    name: "PyLadiesPB",
+    slug: "pyladies-pb",
+    representant: 'Iele Facundo Passo',
+    description:
+      "Comunidade na Paraíba com foco em ajudar mais mulheres a se tornarem participantes ativas e líderes da comunidade de código aberto Python.",
+    category: categories.PARTNER,
+    logo: "https://i.imgur.com/vL74x2k.png",
+    email: "pb@pyladies.com",
+  },
+  {
+    name: "Alt Zap",
+    slug: "alt-zap",
+    representant: 'Luciano de Oliveira Júnior',
+    description:
+      "O Alt Zap é uma aplicação feita para ajudar pequenos e médios negócios a venderem na internet, especialmente pra quem faz entrega por delivery. Atualmente usa tecnologias modernas como React, Gatsby e Firebase e já temos um roadmap bem definido para ser implementado!",
+    category: categories.PARTNER,
+    logo: "https://i.imgur.com/nTUJq2g.png",
+    email: "lucis@vtex.com",
   },
 ];
 

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -177,6 +177,66 @@ const orgs = [
     discord: "https://discord.gg/yzhste8",
     email: "lucis@vtex.com",
   },
+  {
+    name: "Django Public Admin",
+    slug: "django-public-admin",
+    representant: 'Eduardo Cuducos',
+    description:
+      "O Django Public Admin surgiu para ajudar projetos que querem disponibilizar dados publicamente, para humanos, utilizando todo o poder do Django Admin _ mas sem precisar criar contas de usuários, fazer login etc.",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
+  {
+    name: "Calculadora do Cidadão",
+    slug: "calculadora-do-cidadao",
+    representant: 'Eduardo Cuducos',
+    description:
+      "A Calculadora do Cidadão é um pacote em Python para efetuar correção monetária de valores, muito útil em análise históricas. A ideia é criar uma interface unificada para diversos índices econômicos — atualmente temos família IPCA, IGPM, Taxa Selic e FED (EUA).",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
+  {
+    name: "Minha Receita",
+    slug: "minha-receita",
+    representant: 'Eduardo Cuducos',
+    description:
+      "O Minha Receita é uma solução para que pequenas organizações tenham sua própria API web para consulta de informações sobre CNPJ. É uma API construída com base nos dados gerados pela Receita Federal e tratados pelo Brasil.IO.",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
+  {
+    name: "Flask-SimpleLogin",
+    slug: "flask-simple-login",
+    representant: 'Eduardo Cuducos',
+    description:
+      "Flask-SimpleLogin é a solução mais fácil para um sistema super fácil e simples de autenticação de usuário em Flask. Ideal para pequenos projetos, protótipos e MVPs.",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
+  {
+    name: "Flask-AlchemyDumps",
+    slug: "flask-alchemy-dumps",
+    representant: 'Eduardo Cuducos',
+    description:
+      "Flask-AlchemyDumps é uma ferramenta simples de backup de banco de dados para aplicações que utilizam Flask e Flask-SQLAlchemy.",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
+  {
+    name: "GetGist",
+    slug: "get-gist",
+    representant: 'Eduardo Cuducos',
+    description:
+      "GetGist é um programa de linha de comando que permite acesso e atualização de Gists no GitHub como se fossem arquivos locais.",
+    category: categories.PARTNER,
+    discord: "https://discord.gg/yzhste8",
+    email: "cuducos@gmail.com",
+  },
 ];
 
 function getOrg(slug) {

--- a/src/lib/organizations.js
+++ b/src/lib/organizations.js
@@ -8,7 +8,7 @@ const orgs = [
       "A Open Knowledge Brasil (OKBR), também chamada de Rede pelo Conhecimento Livre, é o capítulo da Open Knowledge Internacional no Brasil. Nós utilizamos e desenvolvemos ferramentas cívicas, projetos, análises de políticas públicas, jornalismo de dados e promovemos o conhecimento livre nos diversos campos da sociedade. Na esfera política, buscamos tornar a relação entre governo e sociedade mais próxima e transparente.",
     category: categories.STARS,
     github: "https://github.com/okfn-brasil",
-    logo: "https://www.ok.org.br/wp-content/themes/okbr/assets/images/logo.svg",
+    logo: "https://i.imgur.com/GFqCFMu.png",
   },
   {
     name: "VTEX / SPLab",
@@ -17,7 +17,7 @@ const orgs = [
       "A VTEX é uma empresa global de tecnologia focada em produtos para e-commerce que impacta diariamente o trabalho de milhares de pessoas ao redor do mundo. Através dos seus produtos e serviços, oferece aos lojistas uma plataforma coesa para executar todo o seu negócio e proporcionar aos seus clientes sempre a melhor experiência de compra. No contexto da Universidade Federal de Campina Grande (UFCG), a VTEX e o SPLab firmaram parceria para o desenvolvimento de componentes e soluções da plataforma.",
     category: categories.LAB,
     github: "https://github.com/vtex",
-    logo: "https://i.imgur.com/4Xu1F2m.png",
+    logo: "https://i.imgur.com/xS3ul8s.png",
   },
   {
     name: "Call Us What You Want",
@@ -26,10 +26,10 @@ const orgs = [
       "Call Us What You Want foi criada por José Renan e Robson Junior em 2018 a partir do desejo de desenvolver projetos relacionados com música e de aprender novas tecnologias. O projeto inicial, chamado Musicritic, consiste em uma espécie de avaliador musical. Com o seu desenvolvimento, surgiu um repositório de propósito mais geral: o spotify-web-sdk, trazendo a ideia de facilitar o acesso a dados da API Web do Spotify.",
     category: categories.PARTNER,
     github: "https://github.com/calluswhatyouwant",
-    logo: "https://i.imgur.com/b35mKLg.png",
+    logo: "https://i.imgur.com/Dm8oHwK.png",
   },
   {
-    name: "CAESI - Centro Acadêmico de Ciência da Computação UFCG",
+    name: "CAESI - Centro Acadêmico de Ciência da Computação",
     slug: "caesi",
     description:
       "O CAESI (Centro Acadêmico dos Estudantes de Informática) é o Centro Acadêmico de Ciência da Computação na UFCG, atua na representação do corpo discente do curso e trabalha para melhorar a experiência do estudante durante a graduação.",
@@ -44,7 +44,7 @@ const orgs = [
       "O LSD é um dos Laboratórios de Pesquisa e Desenvolvimento (P&D) da Unidade Acadêmica de Sistemas e Computação da UFCG e realiza ativividades de P&D nas áreas de Computação em Nuvem, Mineração de dados, Computação Social, Big Data e Aplicações.",
     category: categories.LAB,
     github: "https://github.com/ufcg-lsd",
-    logo: "https://i.imgur.com/oadrDYr.png"
+    logo: "https://i.imgur.com/Y7OErgK.png"
   },
   {
     name: "Coordenação de Graduação da UASC",
@@ -53,7 +53,7 @@ const orgs = [
       "A Coordenação de Graduação da UASC é responsável pela gestão das atividades acadêmicas do Curso de Ciência da Computação da UFCG. Nesse contexto, apoia diversas iniciativas de software aberto, incluindo algumas voltadas para melhorar a gestão do curso.",
     category: categories.PARTNER,
     github: "http://www.computacao.ufcg.edu.br/",
-    logo: "https://i.imgur.com/zlNkrUk.png",
+    logo: "https://i.imgur.com/zH2iP6s.png",
   },
 ];
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,15 +33,27 @@ const Home = () => {
               &nbsp; com o intuito de incentivar a participação de estudantes em
               projetos <i>open source</i>!
             </p>
-            <div className="pt-8 pb-4 px-3 w-full text-center block lg:flex lg:flex-row opacity-25 justify-center uppercase font-bold">
-              <Link
-                className="w-full my-2 lg:my-0 lg:w-64 block bg-purple-700 cursor-not-allowed py-4 z-10 rounded"
-                to="/"
-              >
-                Inscrições
+            <div className="w-full block lg:flex items-start">
+              <div className="pt-8 w-full lg:w-1/2 px-3 text-center block lg:flex lg:flex-col items-center justify-center uppercase font-bold">
+                <Link
+                  className="w-full my-2 lg:my-0 lg:w-64 block bg-purple-700 hover:bg-purple-600 py-4 z-10 rounded uppercase"
+                  to="/orgs"
+                >
+                  Organizações
+                </Link>
+              </div>
+              <div className="pt-8 w-full lg:w-1/2 pb-4 px-3 text-center block lg:flex lg:flex-col items-center justify-center uppercase font-bold">
+                <Link
+                  className="w-full my-2 lg:my-0 lg:w-64 block bg-purple-700 cursor-not-allowed py-4 z-10 rounded opacity-25"
+                  to="/"
+                >
+                  Inscrições
               </Link>
+                <div className="uppercase text-secondary-400 font-bold text-sm py-3">
+                  Abertura de inscrições de aprendizes a partir do dia 17 de agosto
+                </div>
+              </div>
             </div>
-            <div className="uppercase text-purple-400 font-bold text-sm">Abertura de inscrições de aprendizes a partir do dia 17/08</div>
           </div>
         </article>
       </section>

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -8,7 +8,7 @@ const OrgsPage = () => {
     <Layout title="Organizações">
       <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
         <div className="w-full flex flex-col pb-5 items-center justify-center">
-          <h1>Organizações</h1>
+          <h1 className="uppercase text-xl font-bold leading-9 text-gray-700">Organizações homologadas</h1>
         </div>
         <div className="w-full px-10 flex flex-wrap justify-center">
           {orgs.map((org, index) => (

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -9,6 +9,9 @@ const OrgsPage = () => {
       <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
         <div className="w-full flex flex-col items-center justify-center">
           <h1 className="mb-8 text-center font-bold text-purple-800 sm:text-lg md:text-xl lg:text-5xl xl:text-5xl">Organizações homologadas</h1>
+          <div className="lg:mx-64 mx-20">
+            Algumas organizações podem ainda não estar aqui listadas por pendências internas.
+          </div>
         </div>
         <div className="w-full px-10 flex flex-wrap justify-center">
           {orgs.map((org, index) => (

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -1,0 +1,22 @@
+import React from "react";
+import OrganizationCard from "../components/organizationCard";
+import Layout from "../components/layouts/layout";
+import { orgs } from "../lib/organizations";
+
+const OrgsPage = () => {
+  return (
+    <Layout title="Organizações">
+      <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
+        <div className="w-full flex flex-col pb-5 items-center justify-center">
+          <h1>Organizações</h1>
+        </div>
+        <div className="w-full px-10 md:px-32 flex flex-wrap justify-center">
+          {orgs.map((org, index) => (
+            <OrganizationCard info={org} key={index} />
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+};
+export default OrgsPage;

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -10,7 +10,7 @@ const OrgsPage = () => {
         <div className="w-full flex flex-col pb-5 items-center justify-center">
           <h1>Organizações</h1>
         </div>
-        <div className="w-full px-10 md:px-32 flex flex-wrap justify-center">
+        <div className="w-full px-10 flex flex-wrap justify-center">
           {orgs.map((org, index) => (
             <OrganizationCard info={org} key={index} />
           ))}

--- a/src/pages/orgs.js
+++ b/src/pages/orgs.js
@@ -5,10 +5,10 @@ import { orgs } from "../lib/organizations";
 
 const OrgsPage = () => {
   return (
-    <Layout title="Organizações">
+    <Layout title="Organizações" className="bg-gray-100">
       <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
-        <div className="w-full flex flex-col pb-5 items-center justify-center">
-          <h1 className="uppercase text-xl font-bold leading-9 text-gray-700">Organizações homologadas</h1>
+        <div className="w-full flex flex-col items-center justify-center">
+          <h1 className="mb-8 text-center font-bold text-purple-800 sm:text-lg md:text-xl lg:text-5xl xl:text-5xl">Organizações homologadas</h1>
         </div>
         <div className="w-full px-10 flex flex-wrap justify-center">
           {orgs.map((org, index) => (

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -6,7 +6,7 @@ import { projects } from "../lib/projects";
 const ProjectsPage = () => {
   return (
     <Layout title="Projetos">
-      <section className="py-10 flex flex-col w-full items-center justify-center">
+      <section className="pt-20 pb-10 flex flex-col w-full items-center justify-center">
         <div className="w-full flex flex-col pb-5 items-center justify-center">
           <h1>Projetos</h1>
         </div>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Project from "../components/project";
+import ProjectCard from "../components/projectCard";
 import Layout from "../components/layouts/layout";
 import { projects } from "../lib/projects";
 
@@ -12,7 +12,7 @@ const ProjectsPage = () => {
         </div>
         <div className="w-full px-32 flex flex-wrap justify-center">
           {projects.map((project, index) => (
-            <Project info={project} key={index} />
+            <ProjectCard info={project} key={index} />
           ))}
         </div>
       </section>

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -1,5 +1,4 @@
-.project {
-    background-color: white;
+.card {
     color: #000;
     margin: 10px;
     display: flex;
@@ -11,6 +10,10 @@
     font-size: 0.8em;
 }
 
-.project:hover {
+.image-container-card {
+    width: 100px;
+}
+
+.card:hover {
     transform: scale(1.07);
 }

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -15,7 +15,7 @@
 
 .org-tag {
   font-size: 0.6rem;
-  @apply font-bold uppercase rounded-md text-center p-2 bg-gray-400 text-gray-600
+  @apply font-bold uppercase rounded-md text-center p-2 bg-gray-400 text-gray-600 w-64
 }
 
 .divider {

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -1,0 +1,31 @@
+.org-logo-container {
+  max-width: 250px;
+  overflow: hidden;
+}
+  
+.org-logo {
+  max-width: 250px;
+}
+
+.org-card {
+  @apply max-w-lg rounded bg-gray-100 overflow-hidden shadow-lg
+}
+
+.org-tag {
+  font-size: 0.6rem;
+  @apply font-bold uppercase rounded-md text-center p-2 bg-purple-800 text-gray-100
+}
+
+.divider {
+  border-top: 1px solid;
+  border-top-color: rgba(0,0,0,0.12);
+  @apply w-full my-4
+}
+
+.org-link {
+  @apply text-primary rounded-sm p-2 w-full text-center
+}
+
+.org-link:hover {
+  @apply bg-purple-600 text-white
+}

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -8,7 +8,7 @@
 }
 
 .org-description {
-  text-indent: 80px;
+  text-indent: 2.5rem;
   text-align: justify;
   @apply text-gray-500 mt-5 text-lg
 }

--- a/src/styles/organization.css
+++ b/src/styles/organization.css
@@ -7,13 +7,15 @@
   max-width: 250px;
 }
 
-.org-card {
-  @apply max-w-lg rounded bg-gray-100 overflow-hidden shadow-lg
+.org-description {
+  text-indent: 80px;
+  text-align: justify;
+  @apply text-gray-500 mt-5 text-lg
 }
 
 .org-tag {
   font-size: 0.6rem;
-  @apply font-bold uppercase rounded-md text-center p-2 bg-purple-800 text-gray-100
+  @apply font-bold uppercase rounded-md text-center p-2 bg-gray-400 text-gray-600
 }
 
 .divider {

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -7,14 +7,14 @@ import '../styles/organization.css'
 
 const Organization = (data) => {
   const slug = data.pageContext.slug;
-  const { name, category, description, github, logo } = getOrg(slug);
+  const { name, category, description, github, logo, email } = getOrg(slug);
 
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
       <article className="pt-20 w-full">
         <div className="flex flex-col md:flex-row mr-auto w-auto items-center md:items-start justify-center">
           <div className="m-10 flex flex-col items-center max-w-lg">
-            <div className="font-bold text-xl mb-2 text-center text-white">{name}</div>
+            <div className="font-bold text-xl uppercase mb-2 text-center text-white">{name}</div>
             <p className="org-description">
               {description}
             </p>
@@ -28,7 +28,7 @@ const Organization = (data) => {
               <div className="org-tag">{category}</div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">
-                <a href={github} className="org-link">Acessar o GitHub</a>
+                <a href={github} className="org-link">Github / Site</a>
               </div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">
@@ -36,15 +36,15 @@ const Organization = (data) => {
               </div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">
-                <a href={github} className="org-link">Enviar e-mail</a>
+                <a href={`mailto:${email}`} className="org-link">E-mail</a>
               </div>
               <div className="divider" />
               <div className="w-full mb-10 mt-8 text-center block justify-center">
                 <Link
-                  className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 rounded"
+                  className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 uppercase font-bold rounded"
                   to="/cronograma"
                 >
-                  Ver projetos
+                  Projetos
                 </Link>
               </div>
             </div>

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -12,19 +12,19 @@ const Organization = (data) => {
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
       <article className="pt-20 w-full">
-        <div className="flex flex-col md:flex-row mr-auto w-auto items-center justify-center">
-          <div className="m-10 flex flex-col items-center max-w-sm">
-            <div className="org-logo-container">
-              <img className="org-logo" src={logo} alt={name} />
-            </div>
-            <p className="text-gray-500 mt-5 text-lg">
+        <div className="flex flex-col md:flex-row mr-auto w-auto items-center md:items-start justify-center">
+          <div className="m-10 flex flex-col items-center max-w-lg">
+            <div className="font-bold text-xl mb-2 text-center text-white">{name}</div>
+            <p className="org-description">
               {description}
             </p>
           </div>
 
-          <div className="org-card">
+          <div className="max-w-lg rounded-none md:rounded-sm bg-gray-100 overflow-hidden shadow-lg">
             <div className="px-8 py-6 flex flex-col items-center">
-              <div className="font-bold text-xl mb-2 text-gray-700">{name}</div>
+              <div className="org-logo-container">
+                <img className="org-logo" src={logo} alt={name} />
+              </div>
               <div className="org-tag">{category}</div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -7,7 +7,7 @@ import '../styles/organization.css'
 
 const Organization = (data) => {
   const slug = data.pageContext.slug;
-  const { name, category, description, github, logo, email } = getOrg(slug);
+  const { name, category, description, logo, email } = getOrg(slug);
 
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
@@ -28,11 +28,7 @@ const Organization = (data) => {
               <div className="org-tag">{category}</div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">
-                <a href={github} className="org-link">Github / Site</a>
-              </div>
-              <div className="divider" />
-              <div className="w-64 flex items-center justify-center">
-                <a href={github} className="org-link">Canal no Discord</a>
+                <a href={`/orgs/${slug}`} className="org-link">Canal no Discord</a>
               </div>
               <div className="divider" />
               <div className="w-64 flex items-center justify-center">

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -23,7 +23,14 @@ const Organization = (data) => {
           <div className="max-w-lg rounded-none md:rounded-sm bg-gray-100 overflow-hidden shadow-lg">
             <div className="px-8 py-6 flex flex-col items-center">
               <div className="org-logo-container">
-                <img className="org-logo" src={logo} alt={name} />
+                {logo ?
+                  (
+                    <img className="org-logo" src={logo} alt={name} />
+                  ) :
+                  (
+                    <p className="uppercase py-3 font-bold">{name}</p>
+                  )
+                }
               </div>
               <div className="org-tag">{category}</div>
               <div className="pt-10 pb-3 w-full text-dark-gray">
@@ -41,11 +48,14 @@ const Organization = (data) => {
               <div className="divider" />
               <div className="w-full mb-10 mt-8 text-center block justify-center">
                 <Link
-                  className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 uppercase font-bold rounded"
-                  to="/cronograma"
+                  className="w-full block text-white bg-purple-800 px-4 py-3 uppercase font-bold rounded opacity-25 cursor-not-allowed"
+                  to={`/orgs/${slug}`}
                 >
                   Projetos
                 </Link>
+                <div className="uppercase text-secondary-400 font-bold text-sm py-3">
+                  Divulgação de projetos inscritos dia 16 de agosto
+                </div>
               </div>
             </div>
           </div>

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Link } from "gatsby";
+
+import { getOrg } from '../lib/organizations'
+import Layout from "../components/layouts/layout";
+import '../styles/organization.css'
+
+const Organization = (data) => {
+  const slug = data.pageContext.slug;
+  const { name, category, description, github, logo } = getOrg(slug);
+
+  return (
+    <Layout Layout title={name} className="bg-dark-gray" >
+      <article className="pt-20 w-full">
+        <div className="flex flex-col md:flex-row mr-auto w-auto justify-center">
+          <div className="m-10 flex flex-col items-center max-w-sm">
+            <div className="org-logo-container">
+              <img className="org-logo" src={logo} alt={name} />
+            </div>
+            <p className="text-gray-500 mt-5 text-lg">
+              {description}
+            </p>
+          </div>
+
+          <div className="org-card">
+            <div className="px-8 py-6 flex flex-col items-center">
+              <div className="font-bold text-xl mb-2 text-gray-700">{name}</div>
+              <div className="org-tag">{category}</div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Acessar o GitHub</a>
+              </div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Canal no Discord</a>
+              </div>
+              <div className="divider" />
+              <div className="w-64 flex items-center justify-center">
+                <a href={github} className="org-link">Enviar e-mail</a>
+              </div>
+              <div className="divider" />
+              <p className="flex text-xs text-gray-700 font-bold self-start mb-3">Tópicos</p>
+              <div>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">nodejs</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ui</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ux</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">react</span>
+                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">devweb</span>
+              </div>
+              <div className="divider" />
+              <div className="w-full mb-12 mt-10 text-center block justify-center">
+                <Link
+                  className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 rounded"
+                  to="/cronograma"
+                >
+                  Ver projetos
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </Layout>
+  )
+}
+
+export default Organization

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -12,7 +12,7 @@ const Organization = (data) => {
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
       <article className="pt-20 w-full">
-        <div className="flex flex-col md:flex-row mr-auto w-auto justify-center">
+        <div className="flex flex-col md:flex-row mr-auto w-auto items-center justify-center">
           <div className="m-10 flex flex-col items-center max-w-sm">
             <div className="org-logo-container">
               <img className="org-logo" src={logo} alt={name} />
@@ -39,16 +39,7 @@ const Organization = (data) => {
                 <a href={github} className="org-link">Enviar e-mail</a>
               </div>
               <div className="divider" />
-              <p className="flex text-xs text-gray-700 font-bold self-start mb-3">Tópicos</p>
-              <div>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">nodejs</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ui</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">ux</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">react</span>
-                <span className="inline-block bg-gray-700 rounded-lg px-3 py-1 text-sm font-semibold text-gray-200 mr-2 my-2">devweb</span>
-              </div>
-              <div className="divider" />
-              <div className="w-full mb-12 mt-10 text-center block justify-center">
+              <div className="w-full mb-10 mt-8 text-center block justify-center">
                 <Link
                   className="w-full block text-white bg-purple-800 hover:bg-purple-600 px-4 py-3 rounded"
                   to="/cronograma"

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -7,7 +7,7 @@ import '../styles/organization.css'
 
 const Organization = (data) => {
   const slug = data.pageContext.slug;
-  const { name, category, description, logo, email } = getOrg(slug);
+  const { name, category, description, logo, email, discord, representant } = getOrg(slug);
 
   return (
     <Layout Layout title={name} className="bg-dark-gray" >
@@ -26,12 +26,16 @@ const Organization = (data) => {
                 <img className="org-logo" src={logo} alt={name} />
               </div>
               <div className="org-tag">{category}</div>
-              <div className="divider" />
-              <div className="w-64 flex items-center justify-center">
-                <a href={`/orgs/${slug}`} className="org-link">Canal no Discord</a>
+              <div className="pt-10 pb-3 w-full text-dark-gray">
+                <p className="uppercase font-bold text-sm">Representante:</p>
+                <p>{representant}</p>
               </div>
               <div className="divider" />
-              <div className="w-64 flex items-center justify-center">
+              <div className="w-full flex items-center justify-center">
+                <a href={discord} className="org-link">Canal no Discord</a>
+              </div>
+              <div className="divider" />
+              <div className="w-full flex items-center justify-center">
                 <a href={`mailto:${email}`} className="org-link">E-mail</a>
               </div>
               <div className="divider" />

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { graphql } from "gatsby";
 
 import Layout from "../components/layouts/layout";


### PR DESCRIPTION
Esta PR adiciona página de organizações homologadas, e uma página para cada uma com o detalhamento.

Close #30 

#### O que foi feito?

Adicionei um campo no `createPages` do arquivo `gatsby-node.js` para criar as páginas das organizações, a partir de um array exportado em `src/lib/organizations.js`.

#### Como suas mudanças podem ser testadas?

Rode o projeto com `yarn && yarn develop` e acesse a rota `/orgs`

[Live preview](https://deploy-preview-32--andromedev.netlify.app/orgs)

#### Screenshots ou exemplos de uso

![image](https://user-images.githubusercontent.com/19390820/89114110-4b5b4900-d44f-11ea-8854-5cdd4a66714f.png)
![image](https://user-images.githubusercontent.com/19390820/89114112-4eeed000-d44f-11ea-8472-e1ca427cefba.png)

- [ ] Conserta bug
- [x] Nova funcionalidade
