### PR TITLE
Auto hiding header on scroll

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,20 +1,46 @@
 import { Link } from "gatsby";
-import React from "react";
+import React, { useState } from "react";
+import useDocumentScrollThrottled from "../helpers/useDocumentScrollThrottled";
 
-const Header = () => (
-  <header className="flex fixed justify-center inset-x-0 top-0 py-4 z-30 bg-dark-gray  text-white">
-    <nav className="uppercase flex justify-around space-x-16">
-      <Link to="/" className="hover:text-orange">
-        INÍCIO
-      </Link>
-      <Link to="/sobre" className="hover:text-orange">
-        SOBRE
-      </Link>
-      <Link to="/guia" className="hover:text-orange">
-        GUIA DE BORDO
-      </Link>
-    </nav>
-  </header>
-);
+function Header() {
+  const [shouldHideHeader, setShouldHideHeader] = useState(false);
+  const [shouldShowShadow, setShouldShowShadow] = useState(false);
+
+  const MINIMUM_SCROLL = 80;
+  const TIMEOUT_DELAY = 400;
+
+  useDocumentScrollThrottled((callbackData) => {
+    const { previousScrollTop, currentScrollTop } = callbackData;
+    const isScrolledDown = previousScrollTop < currentScrollTop;
+    const isMinimumScrolled = currentScrollTop > MINIMUM_SCROLL;
+
+    setShouldShowShadow(currentScrollTop > 2);
+
+    setTimeout(() => {
+      setShouldHideHeader(isScrolledDown && isMinimumScrolled);
+    }, TIMEOUT_DELAY);
+  });
+
+  const shadowStyle = shouldShowShadow ? "shadow" : "";
+  const hiddenStyle = shouldHideHeader ? "hidden" : "";
+
+  return (
+    <header
+      className={`flex fixed justify-center inset-x-0 top-0 py-4 z-30 bg-dark-gray text-white ${hiddenStyle} ${shadowStyle}`}
+    >
+      <nav className="uppercase flex justify-around space-x-16">
+        <Link to="/" className="hover:text-orange">
+          INÍCIO
+        </Link>
+        <Link to="/sobre" className="hover:text-orange">
+          SOBRE
+        </Link>
+        <Link to="/guia" className="hover:text-orange">
+          GUIA DE BORDO
+        </Link>
+      </nav>
+    </header>
+  );
+}
 
 export default Header;

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -54,7 +54,7 @@ const Navbar = ({ currentPage, className }) => {
   return (
     <>
       <button
-        className={`bg-purple-800 w-16 h-16 text-white flex items-center justify-center rounded-full fixed bottom-0 right-0 mr-1 mb-4 xl:hidden`}
+        className={`bg-purple-800 w-16 h-16  text-white flex items-center justify-center rounded-full fixed bottom-0 right-0 mr-1 mb-4 xl:hidden z-40`}
         onClick={() => setIsOpen(!isOpen)}
       >
         {!isOpen ? (

--- a/src/helpers/useDocumentScrollThrottled.js
+++ b/src/helpers/useDocumentScrollThrottled.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+import { throttle } from "lodash";
+
+function useDocumentScrollThrottled(callback) {
+  const [, setScrollPosition] = useState(0);
+  let previousScrollTop = 0;
+
+  function handleDocumentScroll() {
+    const { scrollTop: currentScrollTop } =
+      document.documentElement || document.body;
+
+    setScrollPosition((previousPosition) => {
+      previousScrollTop = previousPosition;
+      return currentScrollTop;
+    });
+
+    callback({ previousScrollTop, currentScrollTop });
+  }
+
+  const handleDocumentScrollThrottled = throttle(handleDocumentScroll, 250);
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleDocumentScrollThrottled);
+
+    return () =>
+      window.removeEventListener("scroll", handleDocumentScrollThrottled);
+  }, [handleDocumentScrollThrottled]);
+}
+
+export default useDocumentScrollThrottled;

--- a/src/pages/cronograma.js
+++ b/src/pages/cronograma.js
@@ -5,7 +5,7 @@ import Layout from "../components/layouts/layout";
 
 const Cronograma = () => {
   return (
-    <Layout title="Cronograma" className="bg-gray-100">
+    <Layout title="Cronograma" className="bg-gray-100 mt-16">
       <h1 className="text-center mb-8 font-bold text-purple-800 sm:text-lg md:text-xl lg:text-5xl xl:text-5xl ">
         Cronograma
       </h1>


### PR DESCRIPTION
<!-- Issue relacionada -->

#29 

#### Qual o propósito dessa pull request?
O header acaba cobrindo parte do conteúdo do markdown do guia, com o header se ocultando a conteúdo ficará visivel ao clicar em um anchor link

<!--- Descreva o problema ou a feature que está sendo proposta aqui. -->

#### O que foi feito?
Uma função para manipular a rolagem da página

<!--- Descreva em detalhes como você implementou a solução -->

#### Como suas mudanças podem ser testadas?
basta rolar a página e ver o header se ocultar

#### Screenshots ou exemplos de uso
![Screen Capture_google-chrome_20200825180041](https://user-images.githubusercontent.com/32929623/91382063-45167d80-e7ff-11ea-9dd7-aa3817520d4f.gif)

<!-- Se aplicável -->

#### Tipo de mudanças

<!-- Marque com um 'x' os tipos de mudanças realizadas -->

- [x] Conserta bug
- [x] Nova funcionalidade

Obs: Além disso, alterei o cronograma para que o título ficasse visível e o botão da navbar para que não ficasse coberto pelo footer no mobile 
